### PR TITLE
Replaced copy_tree from distutils with copytree from shutil to fix script crashing

### DIFF
--- a/URDF_Exporter/utils/utils.py
+++ b/URDF_Exporter/utils/utils.py
@@ -14,7 +14,7 @@ import os.path
 import re
 from xml.etree import ElementTree
 from xml.dom import minidom
-from distutils.dir_util import copy_tree
+from shutil import copytree
 import fileinput
 import sys
 
@@ -174,7 +174,7 @@ def copy_package(save_dir, package_dir):
         os.mkdir(save_dir + '/urdf')
     except:
         pass
-    copy_tree(package_dir, save_dir)
+    copytree(package_dir, save_dir, dirs_exist_ok=True)
 
 
 def update_cmakelists(save_dir, package_name):


### PR DESCRIPTION
Replaced copy_tree from distutils with copytree from shutil to fix script crashing with below error:

```
SCRIPT ERROR

Traceback (most recent call last):
File "/Users/local/Library/Application Support/Autodesk/Autodesk Fusion 360/API/Scripts/URDF_Exporter/URDF_Exporter.py", line 7, in
from .utils import utils
File "/Users/local/Library/Application Support/Autodesk/Autodesk Fusion 360/API/Scripts/URDF_Exporter/utils/utils.py", line 12, in
from distutils.dir_util import copy_tree
ModuleNotFoundError: No module named 'distutils'
```